### PR TITLE
Db form accept header

### DIFF
--- a/js/jquery.check.js
+++ b/js/jquery.check.js
@@ -111,6 +111,8 @@
             return re.test(string);
         },    
         showMessage: function($element, message) {
+            // Set zindex to be lower than jquery-ui dialog
+            $.fn.qtip.zindex = 100;
             var api = $element.qtip('api');
             if ( api === undefined ) {
                 // initialise qtip

--- a/js/jquery.dbForm.js
+++ b/js/jquery.dbForm.js
@@ -147,6 +147,7 @@
 	    }
 	},
 	formAction: function(type,url,handler,errorHandler,async) {
+            // TODO: If type == "info" then ajax GET (instead of POST)
 	    var dbForm = this;
 	    if ( typeof handler == "undefined" ) {
 		handler = function(data, textStatus, jqXHR){
@@ -427,6 +428,7 @@
         var error = $(response).find('error').first();
         if ( error.length == 1 ) {
             this.setState('error');
+            this.setStatus('Changes could not be saved.');
             qcode.alert('Your changes could not be saved:<br>' + error.text());
         }
     }

--- a/js/jquery.dbForm.js
+++ b/js/jquery.dbForm.js
@@ -476,6 +476,7 @@
         });
     }
     function formActionError(errorMessage, errorType, jqXHR) {
+        // Error handler for AJAX errors to let the user know what went wrong. 
         switch(errorType) {
         case 'HTTP':
             var returnType = jqXHR.getResponseHeader('content-type');

--- a/js/jquery.dbForm.js
+++ b/js/jquery.dbForm.js
@@ -32,7 +32,10 @@
                 submitURL: undefined,
                 searchURL: undefined,
                 deleteURL: undefined,
-                formActionReturn: undefined // function
+                formActionReturn: undefined, // function
+                headers: {
+                    Accept: "application/json,text/xml"
+                }
 	    }, options);
 	    if ( typeof this.settings.formActionReturn == "function" ) {
 		this.form.on('formActionReturn.DbForm', this.settings.formActionReturn);
@@ -158,7 +161,7 @@
 	    if ( typeof async == "undefined" ) {
 		async = false;
 	    }
-	    httpPost(url, this.formData(), handler, errorHandler, async);
+	    httpPost(url, this.formData(), handler, errorHandler, async, this.settings.headers);
 	},
 	focus: function() {
 	    this.elements.each(function(){
@@ -188,7 +191,7 @@
 	    var dbForm = this;
 	    httpPost(this.settings.searchURL, data, function(data, textStatus, jqXHR) {
 		formActionSuccess.call(dbForm, data, "search");
-	    }, formActionError.bind(this), true);
+	    }, formActionError.bind(this), true, this.settings.headers);
 	},
 	del: function() {
             var dbForm = this;

--- a/js/jquery.dbForm.js
+++ b/js/jquery.dbForm.js
@@ -422,6 +422,13 @@
 	if ( rec.length == 1 ) {
 	    qcode.alert(rec.text());
 	}
+
+        // Error
+        var error = $(response).find('error').first();
+        if ( error.length == 1 ) {
+            this.setState('error');
+            qcode.alert('Your changes could not be saved:<br>' + error.text());
+        }
     }
     function parseJSONResponse(response, type) {
         // Parses and sets record information and messages from a JSON response.

--- a/js/jquery.dbForm.js
+++ b/js/jquery.dbForm.js
@@ -458,6 +458,7 @@
         }
 
         // Messages
+        var dbForm = this;
         $.each(response.message, function(type, obj) {
             var message = obj.value;
             switch(type) {
@@ -468,7 +469,8 @@
                 dbForm.setStatus(message);
                 break;
             case 'error':
-                qcode.alert(message);
+                dbForm.setState('error');
+                qcode.alert('Your changes could not be saved:<br>' + message);
                 break;
             }
         });

--- a/js/jquery.utils.js
+++ b/js/jquery.utils.js
@@ -127,7 +127,7 @@ function httpPost(url,data,handler,errorHandler,async,headers) {
 	    var error = jQuery('error', data).first();
 	    if ( error.size() ) {
 		var errorMessage = error.text();
-		return errorHandler(errorMessage,'USER');
+		return errorHandler(errorMessage,'USER', jqXHR);
 	    }
 
 	    // NORMAL COMPLETION
@@ -139,24 +139,24 @@ function httpPost(url,data,handler,errorHandler,async,headers) {
 	    // HTTP ERROR
 	    if ( jqXHR.status != 200 && jqXHR.status != 0 ) {
 		errorMessage = "Error ! Expected response 200 but got " + jqXHR.status;
-		return errorHandler(errorMessage,'HTTP');
+		return errorHandler(errorMessage,'HTTP', jqXHR);
 	    }
 
 	    // PARSE ERROR
 	    if ( textStatus == 'parsererror' ) {
 		errorMessage = 'Error ! Unable to parse response';
-		return errorHandler(errorMessage,'PARSE');
+		return errorHandler(errorMessage,'PARSE'. jqXHR);
 	    }
 
             // Cancelled by navigation
             if ( jqXHR.status == 0 && unloading ) {
                 errorMessage = "Request cancelled by navigation";
-                return errorHandler(errorMessage,'NAVIGATION');
+                return errorHandler(errorMessage,'NAVIGATION', jqXHR);
             }
 	    
 	    // DEFAULT ERROR
 	    errorMessage = 'Error ! Test: '+ textStatus;
-	    return errorHandler(errorMessage, 'UNKNOWN');
+	    return errorHandler(errorMessage, 'UNKNOWN', jqXHR);
 	}
     });
 };

--- a/js/jquery.utils.js
+++ b/js/jquery.utils.js
@@ -104,7 +104,7 @@ function urlDataSet(data,name,value) {
     return data;
 };
 
-function httpPost(url,data,handler,errorHandler,async) {
+function httpPost(url,data,handler,errorHandler,async,headers) {
     // Add event listener to check whether request is cancelled by navigation
     var unloading = false;
     $(window).on('beforeunload.httpPost', function() {
@@ -119,6 +119,7 @@ function httpPost(url,data,handler,errorHandler,async) {
 	async: async,
 	url: url,
 	data: data,
+        headers: headers,
 	success: function(data, textStatus, jqXHR) {
             $(window).off('.httpPost');
 


### PR DESCRIPTION
Changes to `dbForm` and `httpPost` to enable use of `Accept` header and to support errors resulting from proper use of HTTP status codes when data is invalid.

JavaScript
-------------
- [x] Does each function have a comment to describe what it does ?
- [x] Are there comments throughout the code ?
- [x] List what testing has been done.
  - Tested with MLA ERP changes.