### PR TITLE
validation autocomplete bug fix

### DIFF
--- a/js/jquery.validation.js
+++ b/js/jquery.validation.js
@@ -83,7 +83,10 @@
                 // Stop the form submission.
                 event.preventDefault();
                 var $form = $(this);
-                
+
+                // blur any text inputs in the form that have focus; otherwise autocomplete popup can become detached from input when validation messages are updated
+                $('input[type=text]:focus', $form).blur();
+
                 // Get rid of old messages
                 $form.validation('hideMessage', 'alert');
                 $form.validation('hideMessage', 'notify');

--- a/js/jquery.validation.js
+++ b/js/jquery.validation.js
@@ -84,8 +84,9 @@
                 event.preventDefault();
                 var $form = $(this);
 
-                // blur any text inputs in the form that have focus; otherwise autocomplete popup can become detached from input when validation messages are updated
-                $('input[type=text]:focus', $form).blur();
+                // blur() then focus() any text inputs in the form that currently have focus
+                // hack to fix bug where autocomplete popup can become detached from input when page layout changes (when error messages displayed/hidden)
+                $('input[type=text]:focus', $form).blur().focus();
 
                 // Get rid of old messages
                 $form.validation('hideMessage', 'alert');


### PR DESCRIPTION
blur any text inputs in the form that have focus; otherwise autocomplete popup can become detached from input when validation messages are updated.

Steps to reproduce.
    * fillout form and have autocomplete popup showing.
    * hit enter key

![image](https://cloud.githubusercontent.com/assets/3089689/12233748/1497d08c-b861-11e5-8bd6-9580221a9761.png)
