### PR TITLE
Preserve Text Selection after XMLSetCellValues (for Cell Out Save)

### DIFF
--- a/js/jquery.dbCell.js
+++ b/js/jquery.dbCell.js
@@ -131,6 +131,19 @@
             cell.trigger('dbCellIn');
 
             this.editor('option', 'tab_on_return', this.options.tab_on_return);
+
+            if ( select === 'preserve' ) {
+                // preserve text selection
+                var textrange = this.editor('getTextrange');
+                if ( textrange.selectionAtStart && textrange.selectionAtEnd ) {
+                    select = 'all';
+                } else if ( textrange.selectionAtStart && textrange.selectionText === '' ) {
+                    select = 'start';
+                } else {
+                    select = 'end';
+                }
+            }
+            
 	    if ( this.getType() === 'combo' ) {
                 var data = this.getRow().dbRow('getRowData');
                 var searchURL = this.getCol().attr('searchURL');

--- a/js/jquery.dbEditorBool.js
+++ b/js/jquery.dbEditorBool.js
@@ -124,7 +124,10 @@
 		this.editor.textrange('set', "all");
 		break;
 	    }
-	}, 
+	},
+        getTextrange: function() {
+            return this.editor.textrange('get');
+        },
 	destroy: function() {
 	    // If the widget is destroyed, remove the editor from the DOM.
 	    this.editor.remove();

--- a/js/jquery.dbEditorCombo.js
+++ b/js/jquery.dbEditorCombo.js
@@ -191,7 +191,10 @@
 		this.editor.textrange('set', "all");
 		break;
 	    }
-	}, 
+	},
+        getTextrange: function() {
+            return this.editor.textrange('get');
+        },
 	search: function() {
 	    // Server side search for available options
 	    dbEditorCombo = this;

--- a/js/jquery.dbEditorHTMLArea.js
+++ b/js/jquery.dbEditorHTMLArea.js
@@ -124,7 +124,10 @@
 		this.editor.textrange('set', "all");
 		break;
 	    }
-	}, 
+	},
+        getTextrange: function() {
+            return this.editor.textrange('get');
+        },
 	destroy: function() {
 	    // If the widget is destroyed, remove the editor from the DOM.
 	    this.editor.remove();

--- a/js/jquery.dbEditorText.js
+++ b/js/jquery.dbEditorText.js
@@ -122,7 +122,10 @@
 		this.editor.textrange('set', "all");
 		break;
 	    }
-	}, 
+	},
+        getTextrange: function() {
+            return this.editor.textrange('get');
+        },
 	destroy: function() {
 	    // If the widget is destroyed, remove the editor from the DOM.
 	    this.editor.remove();

--- a/js/jquery.dbEditorTextArea.js
+++ b/js/jquery.dbEditorTextArea.js
@@ -121,7 +121,10 @@
 		this.editor.textrange('set', "all");
 		break;
 	    }
-	}, 
+	},
+        getTextrange: function() {
+            return this.editor.textrange('get');
+        },
 	destroy: function() {
 	    // If the widget is destroyed, remove the editor from the DOM.
 	    this.editor.remove();

--- a/js/jquery.dbRow.js
+++ b/js/jquery.dbRow.js
@@ -257,7 +257,7 @@
 		    dbRow.setCellValue(colName, value);		    
 		});		
 		if ( currentCell.size() && this.element.find(currentCell).size() ) {
-		    currentCell.dbCell('cellIn', 'end');
+		    currentCell.dbCell('cellIn', 'preserve');
 		}
 	    }
 


### PR DESCRIPTION
Preserve Text Selection after XMLSetCellValues (for Cell Out Save).

Refs: https://github.com/qcode-software/tlc-erp/pull/1737 https://github.com/qcode-software/qcode-ui/issues/178

Ready for merge