### PR TITLE
Throw javascript error on dbFormCombo error

### DIFF
--- a/js/jquery.dbFormCombo.js
+++ b/js/jquery.dbFormCombo.js
@@ -174,6 +174,7 @@
 	        }
 	    }).error(function(jqXHR, textStatus, errorThrown){
 	        dbForm.div.text("Software Bug ! " + errorThrown);
+                throw new Error("Software Bug ! " + errorThrown);
 	    });
         }
     });


### PR DESCRIPTION
Motivation for this is that the error Eli experienced with images this morning.
Throwing this error will be caught by the global page error handler and reported as a bug to support.