### PR TITLE
Bug fix qtip position and add offset

### DIFF
--- a/examples/qcode.qtip.html
+++ b/examples/qcode.qtip.html
@@ -15,6 +15,11 @@
       <label>At <input id="at" value="bottom right"/></label>
     </div>
     <div>
+      Offset:
+      <label>X <input id="offset_x" value="0"/></label>
+      <label>Y <input id="offset_y" value="0"/></label>
+    </div>
+    <div>
       <button id="show">Show</button>
       <button id="hide">Hide</button>
     </div>
@@ -23,6 +28,8 @@
       const input = document.getElementById('input');
       const my = document.getElementById('my');
       const at = document.getElementById('at');
+      const offset_x = document.getElementById('offset_x');
+      const offset_y = document.getElementById('offset_y');
       const qtip = new qcode.Qtip(input, {
           content: "Test",
           position: {
@@ -35,6 +42,10 @@
           qtip.set_content(input.value);
           qtip.options.position.my = my.value;
           qtip.options.position.at = at.value;
+          qtip.options.offset = {
+              x: parseInt(offset_x.value),
+              y: parseInt(offset_y.value)
+          };
           qtip.show();
       });
       const hide = document.getElementById('hide');

--- a/js/qcode.qtip.js
+++ b/js/qcode.qtip.js
@@ -73,6 +73,10 @@ qcode.Qtip = class {
     }
 
     reposition() {
+        this.set_anchor_point({
+            x: 0,
+            y: 0
+        });
         this.set_anchor_point(
             this.get_anchor_point(
                 this.target,
@@ -102,10 +106,16 @@ qcode.Qtip = class {
         const rect = this._getDocumentRect(target);
 
         const horizontal_vertical = this._parse_position_at(position);
-        
+
+        const x = (
+            this._get_x(rect, horizontal_vertical[0]) + this.options.offset.x
+        );
+        const y = (
+            this._get_y(rect, horizontal_vertical[1]) + this.options.offset.y
+        )
         return {
-            x: this._get_x(rect, horizontal_vertical[0]),
-            y: this._get_y(rect, horizontal_vertical[1])
+            x: x,
+            y: y
         }
     }
 
@@ -227,6 +237,10 @@ qcode.Qtip.options = {
     position: {
         my: 'bottom center',
         at: 'bottom center'
+    },
+    offset: {
+        x: 0,
+        y: 0
     },
     classes: [],
     hide_events: [


### PR DESCRIPTION
Testing
----
- Viewed qtip example page
- Set offset for qtip
- Tested with large qtip width on narrow page, "my right center at right center" - confirm this fixes bug encountered on Alistair's machine.


![image](https://user-images.githubusercontent.com/3090503/212137065-be6b8a29-ae35-4a7f-af96-fb7b2343ec36.png)
