### PR TITLE
fix for global functions in jquery.utils.js

### DIFF
--- a/js/jquery.utils.js
+++ b/js/jquery.utils.js
@@ -241,3 +241,22 @@ function scrollToElement($element, duration) {
         }
     }
 }
+
+window.heir = heir;
+window.coalesce = coalesce;
+window.splitURL = splitURL;
+window.formFocus = formFocus;
+window.focusFirstChild = focusFirstChild;
+window.stripHTML = stripHTML;
+window.escapeHTML = escapeHTML;
+window.unescapeHTML = unescapeHTML;
+window.urlSet = urlSet;
+window.urlDataSet = urlDataSet;
+window.httpPost = httpPost;
+window.parseBoolean = parseBoolean;
+window.isEditingKeyEvent = isEditingKeyEvent;
+window.guidGenerate = guidGenerate;
+window.bytesWithUnits2Int = bytesWithUnits2Int;
+window.scrollToElement = scrollToElement;
+window.bytesWithUnits2Int = bytesWithUnits2Int;
+window.scrollToElement = scrollToElement;


### PR DESCRIPTION
To resolve an issue with Babel transpiler cleanup removing unreferenced functions. See [TLC #7576](https://github.com/qcode-software/tlc/issues/7576).